### PR TITLE
Sort by alpha chars when frequency count is equal

### DIFF
--- a/findSuggest/bootstrap.js
+++ b/findSuggest/bootstrap.js
@@ -67,7 +67,10 @@ function getSortedWords(content) {
 
   // Sort words by the most frequent first
   return content.sortedWords = Object.keys(wordFrequency).sort(function(a, b) {
-    return wordFrequency[b] - wordFrequency[a];
+    let freqDelta = wordFrequency[b] - wordFrequency[a];
+    if (0 != freqDelta)
+      return freqDelta;
+    return a < b ? -1 : 1;
   }).map(function(key) key.slice(1));
 }
 


### PR DESCRIPTION
When there are a number of suggestions with the same frequency, then they are currently being displayed in the order that they appeared on the page, instead I was thinking the suggestions should be sorted alphabetically when the frequency is equal.
