### PR TITLE
Word reg exp splitter changes

### DIFF
--- a/findSuggest/bootstrap.js
+++ b/findSuggest/bootstrap.js
@@ -37,6 +37,8 @@
 const Cu = Components.utils;
 Cu.import("resource://gre/modules/Services.jsm");
 
+const SPLITTER = /[-]*[\s\u2010-\u201f\"',\.:;\?!\(\)\{\}\[\]=]+[-]*/
+
 /**
  * Get all the words in the content window sorted by frequency
  */
@@ -52,9 +54,7 @@ function getSortedWords(content) {
   range.collapse(true);
 
   // Count up how many times each word is used ignoring edge punctuation
-  let edges = "[\u2010-\u201f\"',.:;?!()]*";
-  let splitter = RegExp(edges + "\\s+" + edges);
-  let words = text.trim().toLowerCase().split(splitter);
+  let words = text.trim().toLowerCase().split(SPLITTER);
   let wordFrequency = {};
   words.forEach(function(word) {
     // Prepend "w" to avoid special properties like __proto__


### PR DESCRIPTION
I noticed on pages that describe javascript and have something like `function("blah")` in the document, then `function("blah` would be a suggestion for `fun` so I thought that about splitting on spaces and `"`, but the rest of the chars in the `edges` variable that currently exists also looked like they could cause a similar problem, so I think splitting on all of those characters & requiring words to be at least length = 3 is a better solution.

Also making the reg exp a constant.
