### PR TITLE
Clear suggestions when a new tab is selected

### DIFF
--- a/findSuggest/bootstrap.js
+++ b/findSuggest/bootstrap.js
@@ -99,6 +99,7 @@ function addFindSuggestions(window) {
         findContainer.removeChild(node);
     });
   }
+  listen(window.gBrowser.tabContainer, "TabSelect", clearSuggestions);
   unloaders.push(clearSuggestions);
 
   // Show suggestions for the provided word


### PR DESCRIPTION
When I switch tabs using Find Suggest, going from tab A to tab B when I'm on page B I see the suggestions made when I was on page A. These suggestions should be cleared when a new tab is selected, and perhaps the add-on could use another issue to make new suggestions as well.
