### PR TITLE
Bug when pressing delete after left/right after getting a suggestion deletes 2 characters

### DIFF
--- a/speakWords/bootstrap.js
+++ b/speakWords/bootstrap.js
@@ -74,6 +74,10 @@ function addKeywordSuggestions(window) {
       case event.DOM_VK_DELETE:
         deleting = true;
         break;
+      case event.DOM_VK_LEFT:
+      case event.DOM_VK_RIGHT:
+        suggesting = false;
+        break;
     }
   });
 


### PR DESCRIPTION
When pressing delete after left/right after you get a suggestion then this will delete the char where the cursor is, the last char, and moves the cursor to the end of the input.
