### PR TITLE
Using document.createElementNS

### DIFF
--- a/findSuggest/bootstrap.js
+++ b/findSuggest/bootstrap.js
@@ -38,6 +38,8 @@
 const Cu = Components.utils;
 Cu.import("resource://gre/modules/Services.jsm");
 
+const XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
+
 const PREF_BRANCH = "extensions.prospector.findSuggest.";
 const PREFS = {
   minWordLength: 1,
@@ -172,7 +174,7 @@ function addFindSuggestions(window) {
         continue;
 
       // Show these suggestions in the findbar
-      let suggestion = window.document.createElement("label");
+      let suggestion = window.document.createElementNS(XUL_NS, "label");
       suggestion.setAttribute("class", "findbar-suggestion");
       suggestion.setAttribute("style", "margin: 2px 2px 0;");
       suggestion.setAttribute("value", word);


### PR DESCRIPTION
Minor change to use `document.createElementNS` instead of `document.createElement`.
