### PR TITLE
Do not remove last char with suggestion on delete

### DIFF
--- a/speakWords/bootstrap.js
+++ b/speakWords/bootstrap.js
@@ -85,12 +85,7 @@ function addKeywordSuggestions(window) {
   listen(urlBar, "input", function(event) {
     // Don't try suggesting a keyword when the user wants to delete
     if (deleting) {
-      // Clear out the last letter (in addition to the now-removed selection)
-      if (suggesting) {
-        urlBar.value = urlBar.value.slice(0, -1);
-        suggesting = false;
-      }
-      deleting = false;
+      suggesting = deleting = false;
       return;
     }
 


### PR DESCRIPTION
If I wanted to do a google search for "git", then I'd get a suggestion for "github", so then I press delete to get rid of the "hub" part that I don't want and I end up with "gi" (because the "t" is removed as well atm), then I type "t" and get a suggestion for "github" again..
