### PR TITLE
getPref warning

### DIFF
--- a/findSuggest/bootstrap.js
+++ b/findSuggest/bootstrap.js
@@ -64,6 +64,7 @@ function getPref(key) {
     case "string":
       return getPref.branch.getCharPref(key);
   }
+  return null;
 }
 
 /**


### PR DESCRIPTION
I'm seeing the following warning in the error console:

Warning: function getPref does not always return a value
Source File: resource://gre/modules/XPIProvider.jsm -> file:///github/prospector/findSuggest/bootstrap.js
Line: 67, Column: 2
Source Code:
} 
