### PR TITLE
Don't suggest for empty queries

### DIFF
--- a/findSuggest/bootstrap.js
+++ b/findSuggest/bootstrap.js
@@ -20,6 +20,7 @@
  * Contributor(s):
  *   Edward Lee <edilee@mozilla.com>
  *   Erik Vold <erikvvold@gmail.com>
+ *   Greg Parris <greg.parris@gmail.com>
  *
  * Alternatively, the contents of this file may be used under the terms of
  * either the GNU General Public License Version 2 or later (the "GPL"), or


### PR DESCRIPTION
Currently there is no check for whether the suggest query is an empty string.  This means that you can type in something, delete it, and see `limit` # of sorted words.

This commit adds a simple check against the query length.
