### PR TITLE
Shutdown faster

### DIFF
--- a/findSuggest/bootstrap.js
+++ b/findSuggest/bootstrap.js
@@ -278,8 +278,9 @@ function addUnloaderForWindow(window, unload) {
 /**
  * Handle the add-on being deactivated on uninstall/disable
  */
-function shutdown() {
-  unloaders.forEach(function(unload) unload && unload());
+function shutdown(data, reason) {
+  if (reason !== APP_SHUTDOWN)
+    unloaders.forEach(function(unload) unload && unload());
 }
 
 function install() {}

--- a/instantPreview/bootstrap.js
+++ b/instantPreview/bootstrap.js
@@ -219,7 +219,8 @@ function startup(data, reason) AddonManager.getAddonByID(data.id, function(addon
  * Handle the add-on being deactivated on uninstall/disable
  */
 function shutdown(data, reason) {
-  unloaders.forEach(function(unload) unload());
+  if (reason !== APP_SHUTDOWN)
+    unloaders.forEach(function(unload) unload());
 }
 
 /**

--- a/speakWords/bootstrap.js
+++ b/speakWords/bootstrap.js
@@ -367,7 +367,8 @@ function startup(data) AddonManager.getAddonByID(data.id, function(addon) {
  * Handle the add-on being deactivated on uninstall/disable
  */
 function shutdown(data, reason) {
-  unloaders.forEach(function(unload) unload && unload());
+  if (reason !== APP_SHUTDOWN)
+    unloaders.forEach(function(unload) unload && unload());
 }
 
 function install() {}


### PR DESCRIPTION
When the application (Firefox) is being shutdown then there is no reason to run any of the unloaders.
