### PR TITLE
Fix issue 69 search access

### DIFF
--- a/homeDash/bootstrap.js
+++ b/homeDash/bootstrap.js
@@ -1027,11 +1027,11 @@ function addDashboard(window) {
     switch (event.keyCode) {
       case event.DOM_VK_UP:
         history.selectPrevious();
-        event.stopPropagation();
+        event.preventDefault();
         return;
       case event.DOM_VK_DOWN:
         history.selectNext();
-        event.stopPropagation();
+        event.preventDefault();
         return;
     }
 


### PR DESCRIPTION
This enables keyboard accessibility in the way to move up and down in the history search results by using the arrow keys UP and DOWN.
