### PR TITLE
Closes #41 Allow tab completion to finish suggestions to type the next wo

### DIFF
--- a/speakWords/bootstrap.js
+++ b/speakWords/bootstrap.js
@@ -226,6 +226,21 @@ function addEnterSelects(window) {
     gURLBar.mEnterEvent = aEvent;
     gURLBar.controller.handleEnter(true);
   });
+  
+  // Detect Tab press and moves the cursor to the end of current test shown in urlBar
+  listen(window, gURLBar.parentNode, "keypress", function(event) {
+    switch (event.keyCode) {
+      case event.DOM_VK_TAB:  
+	if (gURLBar.value != lastSearch)
+          return;
+		
+	gRLBar.selectTextRange(lastSearch.length,lastSearch.length);
+	event.stopPropagation();
+	event.preventDefault(); 
+        
+        break;	
+    }
+  });  
 
   // Detect deletes of text to avoid accidentally deleting items
   listen(window, gURLBar.parentNode, "keypress", function(event) {


### PR DESCRIPTION
Allows to go to the end of word by pressing TAB rather then switching through the results
