### PR TITLE
Closes #527 Replacing the UP then ENTER combination to just ENTER 

### DIFF
--- a/speakWords/bootstrap.js
+++ b/speakWords/bootstrap.js
@@ -43,9 +43,6 @@ Cu.import("resource://gre/modules/AddonManager.jsm");
 Cu.import("resource://gre/modules/PlacesUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 
-// Remember if the keyword or domain was just completed
-let justCompleted = false;
-
 // Keep a sorted list of keywords to suggest
 let sortedKeywords = [];
 
@@ -120,8 +117,7 @@ function addKeywordSuggestions(window) {
   });
 
   // Watch for urlbar value input changes to suggest keywords
-  listen(window, urlBar, "input", function(event) {
-    justCompleted = false;
+  listen(window, urlBar, "input", function(event) {    
 
     // Don't try suggesting a keyword when the user wants to delete
     if (deleting) {
@@ -137,8 +133,7 @@ function addKeywordSuggestions(window) {
 
     // Select the end of the suggestion to allow over-typing
     urlBar.value = keyword;
-    urlBar.selectTextRange(query.length, keyword.length);
-    justCompleted = true;
+    urlBar.selectTextRange(query.length, keyword.length);    
 
     // Make sure the search suggestions show up
     Utils.delay(function() urlBar.controller.startSearch(urlBar.value));
@@ -202,8 +197,8 @@ function addEnterSelects(window) {
       if (popup.noResults)
         return;
 
-      // Unless we just completed a domain, don't auto-select if we have a url
-      if (!justCompleted && gURLBar.willHandle)
+      // Don't auto-select if we have a url
+      if (gURLBar.willHandle)
         return;
 
       // We passed all the checks, so pretend the user has the first result


### PR DESCRIPTION
Closes #527 Replacing the UP then ENTER combination to just ENTER when the user has "show domain as keyword" preference set to true, by not selecting any popup entry when url is like domain
