### PR TITLE
bug fix: watchWindows runs callback on windows after shutdown

### DIFF
--- a/awesomeBarHD/scripts/utils.js
+++ b/awesomeBarHD/scripts/utils.js
@@ -372,6 +372,9 @@ function unload(callback, container) {
  * @param [function] callback: 1-parameter function that gets a browser window.
  */
 function watchWindows(callback) {
+  var unloaded = false;
+  unload(function() unloaded = true);
+
   // Wrap the callback in a function that ignores failures
   function watcher(window) {
     try {
@@ -388,6 +391,7 @@ function watchWindows(callback) {
     // Listen for one load event before checking the window type
     window.addEventListener("load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
+      if (unloaded) return; // the extension has shutdown
       watcher(window);
     }, false);
   }

--- a/findSuggest/scripts/utils.js
+++ b/findSuggest/scripts/utils.js
@@ -372,6 +372,9 @@ function unload(callback, container) {
  * @param [function] callback: 1-parameter function that gets a browser window.
  */
 function watchWindows(callback) {
+  var unloaded = false;
+  unload(function() unloaded = true);
+
   // Wrap the callback in a function that ignores failures
   function watcher(window) {
     try {
@@ -388,6 +391,7 @@ function watchWindows(callback) {
     // Listen for one load event before checking the window type
     window.addEventListener("load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
+      if (unloaded) return; // the extension has shutdown
       watcher(window);
     }, false);
   }

--- a/homeDash/scripts/utils.js
+++ b/homeDash/scripts/utils.js
@@ -372,6 +372,9 @@ function unload(callback, container) {
  * @param [function] callback: 1-parameter function that gets a browser window.
  */
 function watchWindows(callback) {
+  var unloaded = false;
+  unload(function() unloaded = true);
+
   // Wrap the callback in a function that ignores failures
   function watcher(window) {
     try {
@@ -388,6 +391,7 @@ function watchWindows(callback) {
     // Listen for one load event before checking the window type
     window.addEventListener("load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
+      if (unloaded) return; // the extension has shutdown
       watcher(window);
     }, false);
   }

--- a/instantPreview/scripts/utils.js
+++ b/instantPreview/scripts/utils.js
@@ -372,6 +372,9 @@ function unload(callback, container) {
  * @param [function] callback: 1-parameter function that gets a browser window.
  */
 function watchWindows(callback) {
+  var unloaded = false;
+  unload(function() unloaded = true);
+
   // Wrap the callback in a function that ignores failures
   function watcher(window) {
     try {
@@ -388,6 +391,7 @@ function watchWindows(callback) {
     // Listen for one load event before checking the window type
     window.addEventListener("load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
+      if (unloaded) return; // the extension has shutdown
       watcher(window);
     }, false);
   }

--- a/lessChromeHD/scripts/utils.js
+++ b/lessChromeHD/scripts/utils.js
@@ -372,6 +372,9 @@ function unload(callback, container) {
  * @param [function] callback: 1-parameter function that gets a browser window.
  */
 function watchWindows(callback) {
+  var unloaded = false;
+  unload(function() unloaded = true);
+
   // Wrap the callback in a function that ignores failures
   function watcher(window) {
     try {
@@ -388,6 +391,7 @@ function watchWindows(callback) {
     // Listen for one load event before checking the window type
     window.addEventListener("load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
+      if (unloaded) return; // the extension has shutdown
       watcher(window);
     }, false);
   }

--- a/predictiveNewtab/scripts/utils.js
+++ b/predictiveNewtab/scripts/utils.js
@@ -372,6 +372,9 @@ function unload(callback, container) {
  * @param [function] callback: 1-parameter function that gets a browser window.
  */
 function watchWindows(callback) {
+  var unloaded = false;
+  unload(function() unloaded = true);
+
   // Wrap the callback in a function that ignores failures
   function watcher(window) {
     try {
@@ -388,6 +391,7 @@ function watchWindows(callback) {
     // Listen for one load event before checking the window type
     window.addEventListener("load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
+      if (unloaded) return; // the extension has shutdown
       watcher(window);
     }, false);
   }

--- a/queryStats/scripts/utils.js
+++ b/queryStats/scripts/utils.js
@@ -372,6 +372,9 @@ function unload(callback, container) {
  * @param [function] callback: 1-parameter function that gets a browser window.
  */
 function watchWindows(callback) {
+  var unloaded = false;
+  unload(function() unloaded = true);
+
   // Wrap the callback in a function that ignores failures
   function watcher(window) {
     try {
@@ -388,6 +391,7 @@ function watchWindows(callback) {
     // Listen for one load event before checking the window type
     window.addEventListener("load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
+      if (unloaded) return; // the extension has shutdown
       watcher(window);
     }, false);
   }

--- a/speakWords/scripts/utils.js
+++ b/speakWords/scripts/utils.js
@@ -372,6 +372,9 @@ function unload(callback, container) {
  * @param [function] callback: 1-parameter function that gets a browser window.
  */
 function watchWindows(callback) {
+  var unloaded = false;
+  unload(function() unloaded = true);
+
   // Wrap the callback in a function that ignores failures
   function watcher(window) {
     try {
@@ -388,6 +391,7 @@ function watchWindows(callback) {
     // Listen for one load event before checking the window type
     window.addEventListener("load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
+      if (unloaded) return; // the extension has shutdown
       watcher(window);
     }, false);
   }


### PR DESCRIPTION
watchWindows in utils.js would run callback on windows after shutdown if shutdown occured after a window opened and before the window's loaded event occured
