### PR TITLE
bug fix: unloaders can be added after unload has occured

### DIFF
--- a/awesomeBarHD/scripts/utils.js
+++ b/awesomeBarHD/scripts/utils.js
@@ -322,16 +322,29 @@ function spinQuery(connection, {names, params, query}) {
  * @return [function]: A 0-parameter function that undoes adding the callback.
  */
 function unload(callback, container) {
-  // Initialize the array of unloaders on the first usage
   let unloaders = unload.unloaders;
-  if (unloaders == null)
-    unloaders = unload.unloaders = [];
 
   // Calling with no arguments runs all the unloader callbacks
   if (callback == null) {
-    unloaders.slice().forEach(function(unloader) unloader());
-    unloaders.length = 0;
+    if (unloaders) {
+      unloaders.slice().forEach(function(unloader) unloader());
+      delete unload.unloaders;
+    }
     return;
+  }
+
+  // Wrap the callback in a function that ignores failures
+  function unloader() {
+    try {
+      callback();
+    }
+    catch(ex) {}
+  }
+
+  // call unloader immediately if already unloaded
+  if (!unloaders) {
+    unloader();
+    return function() {};
   }
 
   // The callback is bound to the lifetime of the container if we have one
@@ -347,13 +360,6 @@ function unload(callback, container) {
     }
   }
 
-  // Wrap the callback in a function that ignores failures
-  function unloader() {
-    try {
-      callback();
-    }
-    catch(ex) {}
-  }
   unloaders.push(unloader);
 
   // Provide a way to remove the unloader
@@ -364,6 +370,7 @@ function unload(callback, container) {
   }
   return removeUnloader;
 }
+unload.unloaders = [];
 
 /**
  * Apply a callback to each open and new browser windows.
@@ -386,7 +393,7 @@ function watchWindows(callback) {
   // Wait for the window to finish loading before running the callback
   function runOnLoad(window) {
     // Listen for one load event before checking the window type
-    window.addEventListener("load", function runOnce() {
+    listen(window, window, "load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
       watcher(window);
     }, false);

--- a/findSuggest/scripts/utils.js
+++ b/findSuggest/scripts/utils.js
@@ -322,16 +322,29 @@ function spinQuery(connection, {names, params, query}) {
  * @return [function]: A 0-parameter function that undoes adding the callback.
  */
 function unload(callback, container) {
-  // Initialize the array of unloaders on the first usage
   let unloaders = unload.unloaders;
-  if (unloaders == null)
-    unloaders = unload.unloaders = [];
 
   // Calling with no arguments runs all the unloader callbacks
   if (callback == null) {
-    unloaders.slice().forEach(function(unloader) unloader());
-    unloaders.length = 0;
+    if (unloaders) {
+      unloaders.slice().forEach(function(unloader) unloader());
+      delete unload.unloaders;
+    }
     return;
+  }
+
+  // Wrap the callback in a function that ignores failures
+  function unloader() {
+    try {
+      callback();
+    }
+    catch(ex) {}
+  }
+
+  // call unloader immediately if already unloaded
+  if (!unloaders) {
+    unloader();
+    return function() {};
   }
 
   // The callback is bound to the lifetime of the container if we have one
@@ -347,13 +360,6 @@ function unload(callback, container) {
     }
   }
 
-  // Wrap the callback in a function that ignores failures
-  function unloader() {
-    try {
-      callback();
-    }
-    catch(ex) {}
-  }
   unloaders.push(unloader);
 
   // Provide a way to remove the unloader
@@ -364,6 +370,7 @@ function unload(callback, container) {
   }
   return removeUnloader;
 }
+unload.unloaders = [];
 
 /**
  * Apply a callback to each open and new browser windows.
@@ -386,7 +393,7 @@ function watchWindows(callback) {
   // Wait for the window to finish loading before running the callback
   function runOnLoad(window) {
     // Listen for one load event before checking the window type
-    window.addEventListener("load", function runOnce() {
+    listen(window, window, "load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
       watcher(window);
     }, false);

--- a/homeDash/scripts/utils.js
+++ b/homeDash/scripts/utils.js
@@ -322,16 +322,29 @@ function spinQuery(connection, {names, params, query}) {
  * @return [function]: A 0-parameter function that undoes adding the callback.
  */
 function unload(callback, container) {
-  // Initialize the array of unloaders on the first usage
   let unloaders = unload.unloaders;
-  if (unloaders == null)
-    unloaders = unload.unloaders = [];
 
   // Calling with no arguments runs all the unloader callbacks
   if (callback == null) {
-    unloaders.slice().forEach(function(unloader) unloader());
-    unloaders.length = 0;
+    if (unloaders) {
+      unloaders.slice().forEach(function(unloader) unloader());
+      delete unload.unloaders;
+    }
     return;
+  }
+
+  // Wrap the callback in a function that ignores failures
+  function unloader() {
+    try {
+      callback();
+    }
+    catch(ex) {}
+  }
+
+  // call unloader immediately if already unloaded
+  if (!unloaders) {
+    unloader();
+    return function() {};
   }
 
   // The callback is bound to the lifetime of the container if we have one
@@ -347,13 +360,6 @@ function unload(callback, container) {
     }
   }
 
-  // Wrap the callback in a function that ignores failures
-  function unloader() {
-    try {
-      callback();
-    }
-    catch(ex) {}
-  }
   unloaders.push(unloader);
 
   // Provide a way to remove the unloader
@@ -364,6 +370,7 @@ function unload(callback, container) {
   }
   return removeUnloader;
 }
+unload.unloaders = [];
 
 /**
  * Apply a callback to each open and new browser windows.
@@ -386,7 +393,7 @@ function watchWindows(callback) {
   // Wait for the window to finish loading before running the callback
   function runOnLoad(window) {
     // Listen for one load event before checking the window type
-    window.addEventListener("load", function runOnce() {
+    listen(window, window, "load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
       watcher(window);
     }, false);

--- a/instantPreview/scripts/utils.js
+++ b/instantPreview/scripts/utils.js
@@ -322,16 +322,29 @@ function spinQuery(connection, {names, params, query}) {
  * @return [function]: A 0-parameter function that undoes adding the callback.
  */
 function unload(callback, container) {
-  // Initialize the array of unloaders on the first usage
   let unloaders = unload.unloaders;
-  if (unloaders == null)
-    unloaders = unload.unloaders = [];
 
   // Calling with no arguments runs all the unloader callbacks
   if (callback == null) {
-    unloaders.slice().forEach(function(unloader) unloader());
-    unloaders.length = 0;
+    if (unloaders) {
+      unloaders.slice().forEach(function(unloader) unloader());
+      delete unload.unloaders;
+    }
     return;
+  }
+
+  // Wrap the callback in a function that ignores failures
+  function unloader() {
+    try {
+      callback();
+    }
+    catch(ex) {}
+  }
+
+  // call unloader immediately if already unloaded
+  if (!unloaders) {
+    unloader();
+    return function() {};
   }
 
   // The callback is bound to the lifetime of the container if we have one
@@ -347,13 +360,6 @@ function unload(callback, container) {
     }
   }
 
-  // Wrap the callback in a function that ignores failures
-  function unloader() {
-    try {
-      callback();
-    }
-    catch(ex) {}
-  }
   unloaders.push(unloader);
 
   // Provide a way to remove the unloader
@@ -364,6 +370,7 @@ function unload(callback, container) {
   }
   return removeUnloader;
 }
+unload.unloaders = [];
 
 /**
  * Apply a callback to each open and new browser windows.
@@ -386,7 +393,7 @@ function watchWindows(callback) {
   // Wait for the window to finish loading before running the callback
   function runOnLoad(window) {
     // Listen for one load event before checking the window type
-    window.addEventListener("load", function runOnce() {
+    listen(window, window, "load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
       watcher(window);
     }, false);

--- a/lessChromeHD/scripts/utils.js
+++ b/lessChromeHD/scripts/utils.js
@@ -322,16 +322,29 @@ function spinQuery(connection, {names, params, query}) {
  * @return [function]: A 0-parameter function that undoes adding the callback.
  */
 function unload(callback, container) {
-  // Initialize the array of unloaders on the first usage
   let unloaders = unload.unloaders;
-  if (unloaders == null)
-    unloaders = unload.unloaders = [];
 
   // Calling with no arguments runs all the unloader callbacks
   if (callback == null) {
-    unloaders.slice().forEach(function(unloader) unloader());
-    unloaders.length = 0;
+    if (unloaders) {
+      unloaders.slice().forEach(function(unloader) unloader());
+      delete unload.unloaders;
+    }
     return;
+  }
+
+  // Wrap the callback in a function that ignores failures
+  function unloader() {
+    try {
+      callback();
+    }
+    catch(ex) {}
+  }
+
+  // call unloader immediately if already unloaded
+  if (!unloaders) {
+    unloader();
+    return function() {};
   }
 
   // The callback is bound to the lifetime of the container if we have one
@@ -347,13 +360,6 @@ function unload(callback, container) {
     }
   }
 
-  // Wrap the callback in a function that ignores failures
-  function unloader() {
-    try {
-      callback();
-    }
-    catch(ex) {}
-  }
   unloaders.push(unloader);
 
   // Provide a way to remove the unloader
@@ -364,6 +370,7 @@ function unload(callback, container) {
   }
   return removeUnloader;
 }
+unload.unloaders = [];
 
 /**
  * Apply a callback to each open and new browser windows.
@@ -386,7 +393,7 @@ function watchWindows(callback) {
   // Wait for the window to finish loading before running the callback
   function runOnLoad(window) {
     // Listen for one load event before checking the window type
-    window.addEventListener("load", function runOnce() {
+    listen(window, window, "load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
       watcher(window);
     }, false);

--- a/predictiveNewtab/scripts/utils.js
+++ b/predictiveNewtab/scripts/utils.js
@@ -322,16 +322,29 @@ function spinQuery(connection, {names, params, query}) {
  * @return [function]: A 0-parameter function that undoes adding the callback.
  */
 function unload(callback, container) {
-  // Initialize the array of unloaders on the first usage
   let unloaders = unload.unloaders;
-  if (unloaders == null)
-    unloaders = unload.unloaders = [];
 
   // Calling with no arguments runs all the unloader callbacks
   if (callback == null) {
-    unloaders.slice().forEach(function(unloader) unloader());
-    unloaders.length = 0;
+    if (unloaders) {
+      unloaders.slice().forEach(function(unloader) unloader());
+      delete unload.unloaders;
+    }
     return;
+  }
+
+  // Wrap the callback in a function that ignores failures
+  function unloader() {
+    try {
+      callback();
+    }
+    catch(ex) {}
+  }
+
+  // call unloader immediately if already unloaded
+  if (!unloaders) {
+    unloader();
+    return function() {};
   }
 
   // The callback is bound to the lifetime of the container if we have one
@@ -347,13 +360,6 @@ function unload(callback, container) {
     }
   }
 
-  // Wrap the callback in a function that ignores failures
-  function unloader() {
-    try {
-      callback();
-    }
-    catch(ex) {}
-  }
   unloaders.push(unloader);
 
   // Provide a way to remove the unloader
@@ -364,6 +370,7 @@ function unload(callback, container) {
   }
   return removeUnloader;
 }
+unload.unloaders = [];
 
 /**
  * Apply a callback to each open and new browser windows.
@@ -386,7 +393,7 @@ function watchWindows(callback) {
   // Wait for the window to finish loading before running the callback
   function runOnLoad(window) {
     // Listen for one load event before checking the window type
-    window.addEventListener("load", function runOnce() {
+    listen(window, window, "load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
       watcher(window);
     }, false);

--- a/queryStats/scripts/utils.js
+++ b/queryStats/scripts/utils.js
@@ -322,16 +322,29 @@ function spinQuery(connection, {names, params, query}) {
  * @return [function]: A 0-parameter function that undoes adding the callback.
  */
 function unload(callback, container) {
-  // Initialize the array of unloaders on the first usage
   let unloaders = unload.unloaders;
-  if (unloaders == null)
-    unloaders = unload.unloaders = [];
 
   // Calling with no arguments runs all the unloader callbacks
   if (callback == null) {
-    unloaders.slice().forEach(function(unloader) unloader());
-    unloaders.length = 0;
+    if (unloaders) {
+      unloaders.slice().forEach(function(unloader) unloader());
+      delete unload.unloaders;
+    }
     return;
+  }
+
+  // Wrap the callback in a function that ignores failures
+  function unloader() {
+    try {
+      callback();
+    }
+    catch(ex) {}
+  }
+
+  // call unloader immediately if already unloaded
+  if (!unloaders) {
+    unloader();
+    return function() {};
   }
 
   // The callback is bound to the lifetime of the container if we have one
@@ -347,13 +360,6 @@ function unload(callback, container) {
     }
   }
 
-  // Wrap the callback in a function that ignores failures
-  function unloader() {
-    try {
-      callback();
-    }
-    catch(ex) {}
-  }
   unloaders.push(unloader);
 
   // Provide a way to remove the unloader
@@ -364,6 +370,7 @@ function unload(callback, container) {
   }
   return removeUnloader;
 }
+unload.unloaders = [];
 
 /**
  * Apply a callback to each open and new browser windows.
@@ -386,7 +393,7 @@ function watchWindows(callback) {
   // Wait for the window to finish loading before running the callback
   function runOnLoad(window) {
     // Listen for one load event before checking the window type
-    window.addEventListener("load", function runOnce() {
+    listen(window, window, "load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
       watcher(window);
     }, false);

--- a/speakWords/scripts/utils.js
+++ b/speakWords/scripts/utils.js
@@ -322,16 +322,29 @@ function spinQuery(connection, {names, params, query}) {
  * @return [function]: A 0-parameter function that undoes adding the callback.
  */
 function unload(callback, container) {
-  // Initialize the array of unloaders on the first usage
   let unloaders = unload.unloaders;
-  if (unloaders == null)
-    unloaders = unload.unloaders = [];
 
   // Calling with no arguments runs all the unloader callbacks
   if (callback == null) {
-    unloaders.slice().forEach(function(unloader) unloader());
-    unloaders.length = 0;
+    if (unloaders) {
+      unloaders.slice().forEach(function(unloader) unloader());
+      delete unload.unloaders;
+    }
     return;
+  }
+
+  // Wrap the callback in a function that ignores failures
+  function unloader() {
+    try {
+      callback();
+    }
+    catch(ex) {}
+  }
+
+  // call unloader immediately if already unloaded
+  if (!unloaders) {
+    unloader();
+    return function() {};
   }
 
   // The callback is bound to the lifetime of the container if we have one
@@ -347,13 +360,6 @@ function unload(callback, container) {
     }
   }
 
-  // Wrap the callback in a function that ignores failures
-  function unloader() {
-    try {
-      callback();
-    }
-    catch(ex) {}
-  }
   unloaders.push(unloader);
 
   // Provide a way to remove the unloader
@@ -364,6 +370,7 @@ function unload(callback, container) {
   }
   return removeUnloader;
 }
+unload.unloaders = [];
 
 /**
  * Apply a callback to each open and new browser windows.
@@ -386,7 +393,7 @@ function watchWindows(callback) {
   // Wait for the window to finish loading before running the callback
   function runOnLoad(window) {
     // Listen for one load event before checking the window type
-    window.addEventListener("load", function runOnce() {
+    listen(window, window, "load", function runOnce() {
       window.removeEventListener("load", runOnce, false);
       watcher(window);
     }, false);


### PR DESCRIPTION
Came across this while writing a alternate patch to #559

unloaders can be added after unload has occured, which should not be allowed, and can occur under race conditions like using watchWindows on a opened window that has not yet loaded and disabling the addon before the window completes loading
