### PR TITLE
Closes #563 Trying first Utils.delay() and the Utils.nextTick()

### DIFF
--- a/speakWords/bootstrap.js
+++ b/speakWords/bootstrap.js
@@ -144,7 +144,13 @@ function addKeywordSuggestions(window) {
     justCompleted = true;
 
     // Make sure the search suggestions show up
-    Utils.delay(function() urlBar.controller.startSearch(urlBar.value));
+    // try calling delay() , if fails call nextTick() (For latest Nightlies)
+    try {
+      Utils.delay(function() urlBar.controller.startSearch(urlBar.value));
+    }
+    catch (e) {
+      Utils.nextTick(function() urlBar.controller.startSearch(urlBar.value));
+    }
   });
 }
 


### PR DESCRIPTION
Closes #563 Trying first Utils.delay() for Firefox 4, 5 Beta and 6 Aurora . If it gives exception , call Utils.nextTick() for latest Nightlies
