### PR TITLE
lessChrome: Remove unnecessary code. Bookmark toolbar is part of the gNavToolbox.

### DIFF
--- a/lessChromeHD/bootstrap.js
+++ b/lessChromeHD/bootstrap.js
@@ -105,14 +105,13 @@ function prepareLessChrome(window) {
 
   // Figure out how much to shift the main browser
   let MainBrowser = document.getElementById("browser");
-  let BookmarksToolbar = document.getElementById("PersonalToolbar");
   function updateOffset() {
     // Reset the toolbox to its normal height
     gNavToolbox.style.height = "";
 
     // Do a negative offset of the difference of full height and tabs height
     MainBrowser.style.marginTop = getToolbarHeight() -
-      gNavToolbox.getBoundingClientRect().height + BookmarksToolbar.getBoundingClientRect().height + "px";
+                gNavToolbox.getBoundingClientRect().height + "px";
   }
   updateOffset();
 
@@ -253,7 +252,7 @@ function prepareLessChrome(window) {
     hidden = true;
 
     // Figure out how tall various pieces are
-    let total = gNavToolbox.scrollHeight - BookmarksToolbar.getBoundingClientRect().height;
+    let total = gNavToolbox.scrollHeight;
     let tabs = getToolbarHeight();
     let other = total - tabs;
 


### PR DESCRIPTION
These part of codes are added to solve problem in #516. I guess, at that time, bookmark toolbar is not part of the gNavToolbox. So we had to take into account bookmark toolbar's height separately. But (I don't know from when) now bookmark toolbar is part of the gNavToolbox. Therefore, it causes problem if we take into account its height twice. Specifically, web content move up or down when toolbox (with bookmark bar) is appear or disappear. This patch solve this problem.
